### PR TITLE
Reverted to DropBox for published page saving

### DIFF
--- a/support/published_support.js
+++ b/support/published_support.js
@@ -29,7 +29,9 @@ var add_save_edits_iframe = function () {
     var file_id       = window.location.href.substring(file_id_start+1, file_id_end);
     var iframe        = document.createElement("iframe");
     iframe.className  = "toontalk-saver-iframe";
-    iframe.src        = "https://toontalk.github.io/ToonTalk/support/save_page.html?id=" + file_id;
+    iframe.src        = "https://dl.dropboxusercontent.com/u/51973316/ToonTalk/support/save_page_dropbox.html?id=" + file_id;
+    // using GitHub caused problems with editor fonts not loading
+    //     iframe.src        = "https://toontalk.github.io/ToonTalk/support/save_page.html?id=" + file_id;
     document.body.appendChild(iframe);
 };
 add_save_edits_iframe();


### PR DESCRIPTION
Seems to have a different policy about cross site fonts, etc.
