### PR TITLE
A warning is displayed when running http

### DIFF
--- a/support/utilities.js
+++ b/support/utilities.js
@@ -5861,7 +5861,7 @@ Edited by Ken Kahn for better integration with the rest of the ToonTalk code
             if (typeof TT.cross_origin_url_function === 'undefined') {
                 // might have been set explicitly in index.html or the like
                 // any static web page containing only the word "working" will work
-                // note that if toontalk.appspot.com's quota is exceeded or broken then published pages will be downloaded instead of opened in a new tab 
+                // note that if toontalk.appspot.com's quota is exceeded or broken then published pages will be downloaded instead of opened in a new tab
                 utilities.download_file("https://toontalk.appspot.com/p/https%3A%2F%2Fdrive.google.com%2Fuc%3Fid%3D0B0taMM6vlEqQaWprd2d1ZnlmQWs",
                                         function (contents) {
                                             if (contents && contents.trim() === "working") {

--- a/toontalk.js
+++ b/toontalk.js
@@ -54,6 +54,10 @@ window.TOONTALK = {GOOGLE_DRIVE_CLIENT_ID:  get_parameter('GOOGLE_DRIVE_CLIENT_I
                    CHROME_APP: path_prefix.indexOf("chrome-extension") === 0
                   };
 
+if (TOONTALK.TOONTALK_URL.indexOf("http:") === 0 && !TOONTALK.RUNNING_LOCALLY) {
+    alert("You are using a URL that begins with 'http:'. ToonTalk runs better if the URL starts with 'https:'.");
+}
+
 var reason_unable_to_run = function () {
     // tests on browserstack.com seem to indicate Chrome 31+, FireFox 14+, IE11, Safari 6.2+, Opera 15+
     var is_browser_of_type = function (type) {


### PR DESCRIPTION
Sentry log had errors on iPhone when running the first tour.